### PR TITLE
Implement user invitation system

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -9,6 +9,8 @@
         "email_info": "Wir senden dir einen Bestätigungslink an dein EMail-Konto.",
         "password": "Passwort:",
         "password_info": "Wir verschlüsseln alle Passwörter mit bcrypt, einem der besten Passwort-Hashing-Algorithmen die verfügbar sind.",
+        "invite_code": "Einladungscode:",
+        "invite_code_info": "Du benötigst einen Einladungscode von einem bestehenden Nutzer, um dich zu registrieren.",
         "submit_button": "Registrieren"
     },
     "highscore": {
@@ -74,7 +76,11 @@
     "settings": {
         "title": "Einstellungen",
         "name": "Name (3 bis 30 Zeichen)",
-        "submit_button": "Speichern"
+        "submit_button": "Speichern",
+        "invite_heading": "Freund einladen",
+        "invite_info": "Teile deinen persönlichen Einladungslink mit Freunden, damit sie sich registrieren können.",
+        "invite_copy": "Kopieren",
+        "invite_code_label": "Dein Einladungscode"
     },
     "intro": {
         "title": "Einführung",

--- a/locales/en.json
+++ b/locales/en.json
@@ -9,6 +9,8 @@
         "email_info": "We will send a confirmation link to your email account.",
         "password": "Password:",
         "password_info": "We encrypt all passwords with bcrypt, one of the best password hashing algorithms available.",
+        "invite_code": "Invite Code:",
+        "invite_code_info": "You need an invite code from an existing user to register.",
         "submit_button": "Register"
     },
     "highscore": {
@@ -74,7 +76,11 @@
     "settings": {
         "title": "Settings",
         "name": "Name (3 to 30 characters)",
-        "submit_button": "Save"
+        "submit_button": "Save",
+        "invite_heading": "Invite a Friend",
+        "invite_info": "Share your personal invite link with friends so they can register.",
+        "invite_copy": "Copy",
+        "invite_code_label": "Your invite code"
     },
     "intro": {
         "title": "Intro",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -9,6 +9,8 @@
         "email_info": "Enviaremos um link de confirmação para sua conta de email.",
         "password": "Senha:",
         "password_info": "Criptografamos todas as senhas com bcrypt, um dos melhores algoritmos de hashing de senhas disponíveis.",
+        "invite_code": "Código de convite:",
+        "invite_code_info": "Você precisa de um código de convite de um usuário existente para se registrar.",
         "submit_button": "Registrar"
     },
     "highscore": {
@@ -74,7 +76,11 @@
     "settings": {
         "title": "Configurações",
         "name": "Nome (mínimo de 3 e máximo de 30 caracteres)",
-        "submit_button": "Salvar"
+        "submit_button": "Salvar",
+        "invite_heading": "Convidar um amigo",
+        "invite_info": "Compartilhe seu link de convite pessoal com amigos para que eles possam se registrar.",
+        "invite_copy": "Copiar",
+        "invite_code_label": "Seu código de convite"
     },
     "intro": {
         "title": "Introdução",

--- a/migrations/20260531100000_invite_codes.js
+++ b/migrations/20260531100000_invite_codes.js
@@ -1,0 +1,74 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+    // Add invite_code column to user_account (nullable first so we can backfill)
+    await knex.schema.table("user_account", (table) => {
+        table.text("invite_code").unique();
+    });
+
+    // Backfill existing users with randomly generated 8-char uppercase alphanumeric codes
+    const users = await knex("user_account").select("id");
+    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    function generateCode() {
+        let code = "";
+        for (let i = 0; i < 8; i++) {
+            code += chars[Math.floor(Math.random() * chars.length)];
+        }
+        return code;
+    }
+
+    for (const user of users) {
+        let code;
+        let unique = false;
+        // Retry until we get a unique code (astronomically unlikely to collide)
+        while (!unique) {
+            code = generateCode();
+            const existing = await knex("user_account")
+                .where({ invite_code: code })
+                .first();
+            if (!existing) {
+                unique = true;
+            }
+        }
+        await knex("user_account").where({ id: user.id }).update({ invite_code: code });
+    }
+
+    // Now make the column NOT NULL
+    await knex.schema.raw(
+        `ALTER TABLE user_account ALTER COLUMN invite_code SET NOT NULL`
+    );
+
+    // Create invitation table to track who invited who
+    await knex.schema.createTable("invitation", (table) => {
+        table.increments("id").primary();
+        table
+            .integer("inviter_id")
+            .notNullable()
+            .references("id")
+            .inTable("user_account")
+            .onDelete("CASCADE");
+        table
+            .integer("invitee_id")
+            .notNullable()
+            .references("id")
+            .inTable("user_account")
+            .onDelete("CASCADE");
+        table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+        table.unique(["invitee_id"]); // each user was invited by exactly one person
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+    await knex.schema.dropTable("invitation");
+
+    await knex.schema.table("user_account", (table) => {
+        table.dropColumn("invite_code");
+    });
+};

--- a/routes/admin_invitations.ts
+++ b/routes/admin_invitations.ts
@@ -1,0 +1,108 @@
+import { Router } from "express";
+import { Request, Response } from "express";
+
+import { knex } from "../db";
+import { getUser } from "../request_helper";
+
+const router = Router();
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+}
+
+function buildTreeHtml(
+    nodeId: number,
+    childrenMap: Record<number, { id: number; name: string }[]>
+): string {
+    const children = childrenMap[nodeId];
+    if (!children || children.length === 0) {
+        return "";
+    }
+    const items = children
+        .map((child) => {
+            const escapedName = escapeHtml(child.name);
+
+            return `<li>${escapedName}${buildTreeHtml(
+                child.id,
+                childrenMap
+            )}</li>`;
+        })
+        .join("");
+    return `<ul>${items}</ul>`;
+}
+
+router.get("/admin/invitations", async (req: Request, res: Response) => {
+    const user = getUser(req);
+    if (!user || user.admin !== true) {
+        res.status(404).render("404");
+        return;
+    }
+
+    const invitations = await knex("invitation")
+        .join("user_account as inviter", "inviter.id", "invitation.inviter_id")
+        .join("user_account as invitee", "invitee.id", "invitation.invitee_id")
+        .select<
+            {
+                inviter_id: number;
+                inviter_name: string;
+                invitee_id: number;
+                invitee_name: string;
+                created_at: Date;
+            }[]
+        >(
+            "inviter.id as inviter_id",
+            "inviter.name as inviter_name",
+            "invitee.id as invitee_id",
+            "invitee.name as invitee_name",
+            "invitation.created_at"
+        )
+        .orderBy("invitation.created_at", "asc");
+
+    // Build an invitation tree: map inviter_id -> list of invitees
+    const roots: { id: number; name: string }[] = [];
+    const childrenMap: Record<number, { id: number; name: string }[]> = {};
+    const inviteeIds = new Set(invitations.map((i) => i.invitee_id));
+
+    for (const inv of invitations) {
+        if (!childrenMap[inv.inviter_id]) {
+            childrenMap[inv.inviter_id] = [];
+        }
+        childrenMap[inv.inviter_id].push({
+            id: inv.invitee_id,
+            name: inv.invitee_name,
+        });
+        if (!inviteeIds.has(inv.inviter_id)) {
+            const alreadyRoot = roots.some((r) => r.id === inv.inviter_id);
+            if (!alreadyRoot) {
+                roots.push({ id: inv.inviter_id, name: inv.inviter_name });
+            }
+        }
+    }
+
+    let treeHtml = "";
+    if (roots.length > 0) {
+        const items = roots
+            .map((root) => {
+                const escapedName = root.name
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;");
+                return `<li>${escapedName}${buildTreeHtml(
+                    root.id,
+                    childrenMap
+                )}</li>`;
+            })
+            .join("");
+        treeHtml = `<ul>${items}</ul>`;
+    }
+
+    res.render("admin_invitations", {
+        invitations,
+        treeHtml,
+    });
+});
+
+export default router;

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 import config from "../config";
 import adminExtraBetRouter from "./admin_extra_bet";
+import adminInvitationsRouter from "./admin_invitations";
 import adminRouter from "./admin";
 import autoupdateMatchResultRouter from "./autoupdate_match_result";
 import autoupdateMatchTeamsRouter from "./autoupdate_match_teams";
@@ -35,6 +36,7 @@ router.use(introRouter);
 router.use(userRouter);
 router.use(adminRouter);
 router.use(adminExtraBetRouter);
+router.use(adminInvitationsRouter);
 router.use(mybetsRouter);
 router.use(saveBetRouter);
 router.use(liveRouter);

--- a/routes/register.ts
+++ b/routes/register.ts
@@ -12,6 +12,17 @@ import { sendRawMail } from "./send_mail";
 const BCRYPT_ROUNDS = 10;
 const router = Router();
 
+const INVITE_CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const INVITE_CODE_LENGTH = 8;
+
+export function generateInviteCode(): string {
+    let code = "";
+    for (let i = 0; i < INVITE_CODE_LENGTH; i++) {
+        code += INVITE_CODE_CHARS[Math.floor(Math.random() * INVITE_CODE_CHARS.length)];
+    }
+    return code;
+}
+
 const MAIL_TEMPLATE = `Hello {{{name}}},
 thank you for registering for the Worldcup 2026 Betting Game.
 
@@ -62,6 +73,7 @@ router.get("/register", function (req: Request, res: Response) {
         error: req.flash("error"),
         name: req.flash("name"),
         email: req.flash("email"),
+        inviteCode: req.flash("inviteCode")[0] ?? (req.query.invite as string) ?? "",
         disabled: config.disableUserRegistration,
     });
 });
@@ -73,13 +85,33 @@ router.post("/register", async (req, res) => {
         return;
     }
 
-    // Save name and email in flash
+    // Preserve form values across redirect
     req.flash("name", req.body.name);
     req.flash("email", req.body.email);
+    req.flash("inviteCode", req.body.invite_code);
+
+    // Validate invite code
+    const suppliedCode = (req.body.invite_code ?? "").trim().toUpperCase();
+    if (!suppliedCode) {
+        req.flash("error", "An invite code is required to register.");
+        res.redirect("/register");
+        return;
+    }
+
+    const inviter = await knex("user_account")
+        .select("id")
+        .where({ invite_code: suppliedCode })
+        .first();
+
+    if (!inviter) {
+        req.flash("error", "Invalid invite code.");
+        res.redirect("/register");
+        return;
+    }
 
     const encrypted = await bcrypt.hash(req.body.password, BCRYPT_ROUNDS);
-
     const token = uuidv4();
+    const newInviteCode = generateInviteCode();
 
     let user: RegistrationUser | null = null;
 
@@ -91,6 +123,7 @@ router.post("/register", async (req, res) => {
                 email: req.body.email,
                 email_confirmed: false,
                 email_confirm_token: token,
+                invite_code: newInviteCode,
                 created_at: knex.fn.now(),
                 past_matches_last_visited_at: knex.fn.now(),
             })
@@ -116,6 +149,13 @@ router.post("/register", async (req, res) => {
         res.redirect("/register");
         return;
     }
+
+    // Record the invitation relationship
+    await knex("invitation").insert({
+        inviter_id: inviter.id,
+        invitee_id: user.id,
+        created_at: knex.fn.now(),
+    });
 
     if (config.mail) {
         sendMail(user)

--- a/routes/settings.ts
+++ b/routes/settings.ts
@@ -7,17 +7,26 @@ import { getUser } from "../request_helper";
 
 const router = Router();
 
-router.get("/settings", (req: Request, res: Response) => {
+router.get("/settings", async (req: Request, res: Response) => {
     const user = getUser(req);
     if (!user) {
         res.redirect("/login");
         return;
     }
 
+    const dbUser = await knex("user_account")
+        .select("invite_code")
+        .where({ id: user.id })
+        .first();
+
     res.render("settings", {
         enabledFacebook: !!config.facebook,
         enabledGoogle: !!config.google,
         error: req.flash("error"),
+        inviteCode: dbUser?.invite_code ?? null,
+        inviteLink: dbUser?.invite_code
+            ? config.origin + "/register?invite=" + dbUser.invite_code
+            : null,
     });
 });
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,0 +1,19 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var btn = document.getElementById("copyInviteLinkBtn");
+    if (!btn) return;
+    var originalText = btn.textContent;
+    btn.addEventListener("click", function () {
+        var input = document.getElementById("inviteLinkInput");
+        if (!input) return;
+        navigator.clipboard.writeText(input.value).then(function () {
+            btn.textContent = "✓ Copied!";
+            btn.classList.add("btn-success");
+            btn.classList.remove("btn-outline-secondary");
+            setTimeout(function () {
+                btn.textContent = originalText;
+                btn.classList.remove("btn-success");
+                btn.classList.add("btn-outline-secondary");
+            }, 2000);
+        });
+    });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,6 +1,7 @@
 import bcrypt from "bcrypt";
 import supertest from "supertest";
 import app from "../app";
+import { generateInviteCode } from "../routes/register";
 
 export const agent = () => supertest.agent(app);
 
@@ -33,6 +34,7 @@ export async function createTestUser(
             password: hash,
             admin: overrides.admin ?? false,
             email_confirmed: true,
+            invite_code: generateInviteCode(),
             created_at: new Date(),
             past_matches_last_visited_at: new Date(),
         })
@@ -66,7 +68,7 @@ export async function authenticatedAgent(
  */
 export async function truncateTables(knex: import("knex").Knex): Promise<void> {
     await knex.raw(
-        "TRUNCATE TABLE bet, friend, user_account, match, team, match_type, extra_bet, user_account_extra_bet RESTART IDENTITY CASCADE"
+        "TRUNCATE TABLE bet, friend, invitation, user_account, match, team, match_type, extra_bet, user_account_extra_bet RESTART IDENTITY CASCADE"
     );
 }
 

--- a/tests/routes/admin_invitations.test.ts
+++ b/tests/routes/admin_invitations.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { knex } from "../../db";
+import { authenticatedAgent, createTestUser, truncateTables } from "../helpers";
+
+describe("GET /admin/invitations", () => {
+    beforeEach(async () => {
+        await truncateTables(knex);
+    });
+
+    afterEach(async () => {
+        await truncateTables(knex);
+    });
+
+    it("returns 404 for anonymous users", async () => {
+        const { default: supertest } = await import("supertest");
+        const { default: app } = await import("../../app");
+
+        const res = await supertest(app).get("/admin/invitations");
+        expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for non-admin logged-in users", async () => {
+        const user = await createTestUser(knex, { admin: false });
+        const ag = await authenticatedAgent(user);
+
+        const res = await ag.get("/admin/invitations");
+        expect(res.status).toBe(404);
+    });
+
+    it("returns 200 for admin users with empty invitation list", async () => {
+        const admin = await createTestUser(knex, { admin: true });
+        const ag = await authenticatedAgent(admin);
+
+        const res = await ag.get("/admin/invitations");
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("No invitations recorded yet.");
+    });
+
+    it("shows invitation relationships for admin users", async () => {
+        const inviter = await createTestUser(knex, { name: "Alice", email: "alice@example.com" });
+        const invitee = await createTestUser(knex, { name: "Bob", email: "bob@example.com" });
+
+        await knex("invitation").insert({
+            inviter_id: inviter.id,
+            invitee_id: invitee.id,
+            created_at: new Date(),
+        });
+
+        const admin = await createTestUser(knex, { admin: true, email: "admin@example.com" });
+        const ag = await authenticatedAgent(admin);
+
+        const res = await ag.get("/admin/invitations");
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("Alice");
+        expect(res.text).toContain("Bob");
+    });
+});

--- a/tests/routes/register.test.ts
+++ b/tests/routes/register.test.ts
@@ -38,7 +38,12 @@ describe("POST /register", () => {
         await truncateTables(knex);
     });
 
-    it("creates user and redirects to /intro when no mail configured", async () => {
+    async function getInviterCode(knex: import("knex").Knex, inviterId: number): Promise<string> {
+        const row = await knex("user_account").select("invite_code").where({ id: inviterId }).first();
+        return row.invite_code;
+    }
+
+    it("rejects registration without an invite code", async () => {
         const { default: supertest } = await import("supertest");
         const { default: app } = await import("../../app");
         const ag = supertest.agent(app);
@@ -49,17 +54,32 @@ describe("POST /register", () => {
             .send({ name: "New User", email: "newuser@example.com", password: "secret123" });
 
         expect(res.status).toBe(302);
-        expect(res.headers.location).toBe("/intro");
+        expect(res.headers.location).toBe("/register");
 
-        const dbUser = await knex("user_account")
-            .where({ email: "newuser@example.com" })
-            .first();
-        expect(dbUser).toBeDefined();
-        expect(dbUser.name).toBe("New User");
+        const dbUser = await knex("user_account").where({ email: "newuser@example.com" }).first();
+        expect(dbUser).toBeUndefined();
     });
 
-    it("redirects back to /register on duplicate email", async () => {
-        await createTestUser(knex, { email: "taken@example.com" });
+    it("rejects registration with an invalid invite code", async () => {
+        const { default: supertest } = await import("supertest");
+        const { default: app } = await import("../../app");
+        const ag = supertest.agent(app);
+
+        const res = await ag
+            .post("/register")
+            .type("form")
+            .send({ name: "New User", email: "newuser@example.com", password: "secret123", invite_code: "BADCODE1" });
+
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toBe("/register");
+
+        const dbUser = await knex("user_account").where({ email: "newuser@example.com" }).first();
+        expect(dbUser).toBeUndefined();
+    });
+
+    it("creates user and redirects to /intro with a valid invite code", async () => {
+        const inviter = await createTestUser(knex);
+        const inviteCode = await getInviterCode(knex, inviter.id);
 
         const { default: supertest } = await import("supertest");
         const { default: app } = await import("../../app");
@@ -68,7 +88,51 @@ describe("POST /register", () => {
         const res = await ag
             .post("/register")
             .type("form")
-            .send({ name: "Duplicate", email: "taken@example.com", password: "secret123" });
+            .send({ name: "New User", email: "newuser@example.com", password: "secret123", invite_code: inviteCode });
+
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toBe("/intro");
+
+        const dbUser = await knex("user_account").where({ email: "newuser@example.com" }).first();
+        expect(dbUser).toBeDefined();
+        expect(dbUser.name).toBe("New User");
+        expect(dbUser.invite_code).toBeDefined();
+        expect(dbUser.invite_code).not.toBe(inviteCode);
+    });
+
+    it("records invitation relationship after successful registration", async () => {
+        const inviter = await createTestUser(knex);
+        const inviteCode = await getInviterCode(knex, inviter.id);
+
+        const { default: supertest } = await import("supertest");
+        const { default: app } = await import("../../app");
+        const ag = supertest.agent(app);
+
+        await ag
+            .post("/register")
+            .type("form")
+            .send({ name: "Invited User", email: "invited@example.com", password: "secret123", invite_code: inviteCode });
+
+        const invitee = await knex("user_account").where({ email: "invited@example.com" }).first();
+        const invitation = await knex("invitation")
+            .where({ inviter_id: inviter.id, invitee_id: invitee.id })
+            .first();
+
+        expect(invitation).toBeDefined();
+    });
+
+    it("redirects back to /register on duplicate email", async () => {
+        const inviter = await createTestUser(knex, { email: "taken@example.com" });
+        const inviteCode = await getInviterCode(knex, inviter.id);
+
+        const { default: supertest } = await import("supertest");
+        const { default: app } = await import("../../app");
+        const ag = supertest.agent(app);
+
+        const res = await ag
+            .post("/register")
+            .type("form")
+            .send({ name: "Duplicate", email: "taken@example.com", password: "secret123", invite_code: inviteCode });
 
         expect(res.status).toBe(302);
         expect(res.headers.location).toBe("/register");
@@ -111,6 +175,7 @@ describe("POST /activate/:code", () => {
             admin: false,
             email_confirmed: false,
             email_confirm_token: token,
+            invite_code: "TESTCODE",
             created_at: new Date(),
             past_matches_last_visited_at: new Date(),
         });

--- a/views/admin.hbs
+++ b/views/admin.hbs
@@ -95,5 +95,10 @@
 {{/each}}
 
 </div>
+
+<div class="container my-4">
+<h3>Invitations</h3>
+<a class="btn btn-outline-secondary" href="/admin/invitations">View Invitation Graph</a>
+</div>
 {{/inline}}
 {{/layout}}

--- a/views/admin_invitations.hbs
+++ b/views/admin_invitations.hbs
@@ -1,0 +1,43 @@
+{{#> layout}}
+{{#*inline "head"}}
+<title>Invitations - {{@websiteName}}</title>
+{{/inline}}
+{{#*inline "body"}}
+{{> navbar}}
+<div class="container">
+<h2>Invitation Graph</h2>
+<p><a href="/admin">&larr; Back to Admin</a></p>
+
+<h3>Flat List</h3>
+{{#if invitations.length}}
+<table class="table table-sm">
+    <thead>
+        <tr>
+            <th>Inviter</th>
+            <th>Invitee</th>
+            <th>Date</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{#each invitations}}
+        <tr>
+            <td>{{inviter_name}}</td>
+            <td>{{invitee_name}}</td>
+            <td>{{calendarShort created_at}}</td>
+        </tr>
+        {{/each}}
+    </tbody>
+</table>
+{{else}}
+<p class="text-muted">No invitations recorded yet.</p>
+{{/if}}
+
+<h3 class="mt-4">Tree View</h3>
+{{#if treeHtml}}
+{{{treeHtml}}}
+{{else}}
+<p class="text-muted">No invitations yet.</p>
+{{/if}}
+</div>
+{{/inline}}
+{{/layout}}

--- a/views/register.hbs
+++ b/views/register.hbs
@@ -19,6 +19,13 @@
         {{/if}}
         <input type="hidden" name="_csrf" value="{{csrfToken}}">
         <div class="mb-3">
+            <label for="invite_code">{{ t "register.invite_code" }}</label>
+            <input type="text" class="form-control" name="invite_code" id="invite_code" maxlength="8" required value="{{inviteCode}}" autocomplete="off" style="text-transform:uppercase">
+            <small class="form-text text-muted">
+                {{ t "register.invite_code_info" }}
+            </small>
+        </div>
+        <div class="mb-3">
             <label for="name">{{ t "register.name" }}</label>
             <input type="text" class="form-control" name="name" id="name" minlength="3" maxlength="30" required value="{{name}}">
             <small class="form-text text-muted">

--- a/views/settings.hbs
+++ b/views/settings.hbs
@@ -27,6 +27,19 @@
 
 <hr/>
 
+{{#if inviteCode}}
+<h3>{{ t "settings.invite_heading" }}</h3>
+<p>{{ t "settings.invite_info" }}</p>
+<div class="input-group mb-2">
+    <input type="text" class="form-control" id="inviteLinkInput" value="{{inviteLink}}" readonly>
+    <button class="btn btn-outline-secondary" type="button" onclick="navigator.clipboard.writeText(document.getElementById('inviteLinkInput').value)">
+        {{ t "settings.invite_copy" }}
+    </button>
+</div>
+<p class="text-muted">{{ t "settings.invite_code_label" }}: <strong>{{inviteCode}}</strong></p>
+<hr/>
+{{/if}}
+
 {{#if enabledFacebook}}
 {{#if user.facebookId}}
 <div class="alert alert-success">

--- a/views/settings.hbs
+++ b/views/settings.hbs
@@ -32,7 +32,7 @@
 <p>{{ t "settings.invite_info" }}</p>
 <div class="input-group mb-2">
     <input type="text" class="form-control" id="inviteLinkInput" value="{{inviteLink}}" readonly>
-    <button class="btn btn-outline-secondary" type="button" onclick="navigator.clipboard.writeText(document.getElementById('inviteLinkInput').value)">
+    <button class="btn btn-outline-secondary" type="button" id="copyInviteLinkBtn">
         {{ t "settings.invite_copy" }}
     </button>
 </div>
@@ -85,5 +85,8 @@ We will NOT store any additional information except for your profile ID.
 {{/if}}
 
 </div>
+{{/inline}}
+{{#*inline "scripts"}}
+<script type="text/javascript" src="/static/js/settings.js"></script>
 {{/inline}}
 {{/layout}}


### PR DESCRIPTION
**Database**
- New migration: adds `invite_code` (unique 8-char alphanumeric) column to `user_account`; backfills all existing users with auto-generated codes
- New `invitation` table recording who invited who (`inviter_id`, `invitee_id`, `created_at`); each user can have at most one inviter

**Registration**
- Registration now requires a valid invite code; submitting without one or with an unknown code is rejected with an error message
- New registrants automatically receive their own invite code
- The invite code from `?invite=CODE` query parameter is pre-filled in the form
- Invite codes are case-insensitive on input (uppercased before lookup)

**Settings page**
- Logged-in users can see their personal invite link and code
- "Copy" button copies the invite link to the clipboard and shows a brief "✓ Copied!" confirmation

**Admin**
- New `/admin/invitations` page showing a flat table and a nested tree of all invitations (who invited who)
- Link to the invitations page added to the admin panel
