### PR TITLE
Hide bots on live matches, past matches and extra-bet-list

### DIFF
--- a/migrations/20260614110000_is_bot.js
+++ b/migrations/20260614110000_is_bot.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+    await knex.schema.alterTable("user_account", (table) => {
+        table.boolean("is_bot").notNullable().defaultTo(false);
+    });
+};
+
+exports.down = async (knex) => {
+    await knex.schema.alterTable("user_account", (table) => {
+        table.dropColumn("is_bot");
+    });
+};

--- a/routes/extra_bet_list.ts
+++ b/routes/extra_bet_list.ts
@@ -42,6 +42,7 @@ router.get("/extra_bet_list", async (req: Request, res: Response) => {
                     cross join unnest(selected_team_ids) as t(id)
                     join user_account on (user_account_extra_bet.user_id = user_account.id)
                     where user_account_extra_bet.extra_bet_id = extra_bet.id
+                    and not user_account.is_bot
                     group by t.id
                     order by count(*) desc, t.id
                 ) grouped_team

--- a/routes/live.ts
+++ b/routes/live.ts
@@ -98,7 +98,10 @@ router.get("/live", async (req: Request, res: Response) => {
         -- No LEFT JOIN here to discard matches without bets (and prevent division by zero)
         JOIN bet ON match.id = bet.match_id
         JOIN user_account ON user_account.id = bet.user_id
-        WHERE now() > match.starts_at AND match.goals_home IS NULL AND match.goals_away IS NULL
+        WHERE now() > match.starts_at
+        AND match.goals_home IS NULL
+        AND match.goals_away IS NULL
+        AND NOT user_account.is_bot
         GROUP BY match.id;
     `,
         {
@@ -151,7 +154,9 @@ router.get("/live", async (req: Request, res: Response) => {
             (
                 select count(*)
                 from bet
+                join user_account on (user_account.id = bet.user_id)
                 where bet.match_id = match.id
+                and not user_account.is_bot
             ) as bet_count,
             (
                 select coalesce(array_agg(jsonb_build_object(
@@ -161,6 +166,7 @@ router.get("/live", async (req: Request, res: Response) => {
                 from user_account
                 join friend on (friend.to_user_id = user_account.id)
                 where friend.from_user_id = :id
+                and not user_account.is_bot
                 and
                     not exists (
                         select 1

--- a/routes/past.ts
+++ b/routes/past.ts
@@ -45,6 +45,7 @@ router.get("/past", async (req: Request, res: Response) => {
                 from bet
                 join user_account on (bet.user_id = user_account.id)
                 where bet.match_id = match.id
+                and not user_account.is_bot
             ) as all_bets,
 
             (
@@ -55,7 +56,9 @@ router.get("/past", async (req: Request, res: Response) => {
                     'draw', count(1) filter (where bet.goals_home = bet.goals_away)
                 )
                 from bet
+                join user_account on (bet.user_id = user_account.id)
                 where bet.match_id = match.id
+                and not user_account.is_bot
             ) as bet_counts,
 
             :logged_in and (goals_inserted_at > :last_visited or :last_visited::timestamptz is null) as unseen,
@@ -70,7 +73,9 @@ router.get("/past", async (req: Request, res: Response) => {
                     )), 1)
                 from friend
                 join bet as friend_bet on (friend_bet.user_id = friend.to_user_id)
+                join user_account as friend_user on (friend_user.id = friend.to_user_id)
                 where friend.from_user_id = :id
+                and not friend_user.is_bot
                 and friend_bet.match_id = match.id
             ) as avg_friend_score,
 
@@ -98,7 +103,9 @@ router.get("/past", async (req: Request, res: Response) => {
                         )), 1)
                     from friend
                     join bet as friend_bet on (friend_bet.user_id = friend.to_user_id)
+                    join user_account as friend_user on (friend_user.id = friend.to_user_id)
                     where friend.from_user_id = :id
+                    and not friend_user.is_bot
                     and friend_bet.match_id = match.id
                 )
             ) as my_gain
@@ -125,15 +132,23 @@ router.get("/past", async (req: Request, res: Response) => {
     );
 
     for (const match of matches.rows) {
-        match.percent = {
-            home: Math.round(
-                (match.bet_counts.home / match.bet_counts.total) * 100
-            ),
-            away: Math.round(
-                (match.bet_counts.away / match.bet_counts.total) * 100
-            ),
-        };
-        match.percent.draw = 100 - match.percent.home - match.percent.away;
+        if (match.bet_counts.total > 0) {
+            match.percent = {
+                home: Math.round(
+                    (match.bet_counts.home / match.bet_counts.total) * 100
+                ),
+                away: Math.round(
+                    (match.bet_counts.away / match.bet_counts.total) * 100
+                ),
+            };
+            match.percent.draw = 100 - match.percent.home - match.percent.away;
+        } else {
+            match.percent = {
+                home: 0,
+                away: 0,
+                draw: 0,
+            };
+        }
 
         const bets: Record<string, unknown[]> = {
             correct: [],

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -13,6 +13,7 @@ export interface TestUser {
     password: string;
     name: string;
     admin?: boolean;
+    is_bot?: boolean;
 }
 
 /**
@@ -33,6 +34,7 @@ export async function createTestUser(
             name,
             password: hash,
             admin: overrides.admin ?? false,
+            is_bot: overrides.is_bot ?? false,
             email_confirmed: true,
             invite_code: generateInviteCode(),
             created_at: new Date(),

--- a/tests/routes/live.test.ts
+++ b/tests/routes/live.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { knex } from "../../db";
-import { authenticatedAgent, createTestUser, truncateTables } from "../helpers";
+import {
+    authenticatedAgent,
+    createTestUser,
+    seedMatch,
+    seedTeam,
+    truncateTables,
+} from "../helpers";
 
 describe("GET /live", () => {
     beforeEach(async () => {
@@ -25,5 +31,33 @@ describe("GET /live", () => {
 
         const res = await ag.get("/live");
         expect(res.status).toBe(200);
+    });
+
+    it("does not render bot users on the live matches page", async () => {
+        const homeTeamId = await seedTeam(knex, { name: "Home Team", code: "HTM" });
+        const awayTeamId = await seedTeam(knex, { name: "Away Team", code: "AWY" });
+        const matchId = await seedMatch(knex, {
+            starts_at: new Date(Date.now() - 60 * 1000),
+            home_team_id: homeTeamId,
+            away_team_id: awayTeamId,
+        });
+
+        const human = await createTestUser(knex, { name: "Visible Human" });
+        const bot = await createTestUser(knex, {
+            email: "bot-live@example.com",
+            name: "Hidden Bot",
+            is_bot: true,
+        });
+
+        await knex("bet").insert([
+            { user_id: human.id, match_id: matchId, goals_home: 2, goals_away: 1 },
+            { user_id: bot.id, match_id: matchId, goals_home: 0, goals_away: 3 },
+        ]);
+
+        const res = await authenticatedAgent(human).then((ag) => ag.get("/live"));
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("Visible Human");
+        expect(res.text).not.toContain("Hidden Bot");
     });
 });

--- a/tests/routes/live.test.ts
+++ b/tests/routes/live.test.ts
@@ -34,8 +34,14 @@ describe("GET /live", () => {
     });
 
     it("does not render bot users on the live matches page", async () => {
-        const homeTeamId = await seedTeam(knex, { name: "Home Team", code: "HTM" });
-        const awayTeamId = await seedTeam(knex, { name: "Away Team", code: "AWY" });
+        const homeTeamId = await seedTeam(knex, {
+            name: "Home Team",
+            code: "HTM",
+        });
+        const awayTeamId = await seedTeam(knex, {
+            name: "Away Team",
+            code: "AWY",
+        });
         const matchId = await seedMatch(knex, {
             starts_at: new Date(Date.now() - 60 * 1000),
             home_team_id: homeTeamId,
@@ -50,11 +56,23 @@ describe("GET /live", () => {
         });
 
         await knex("bet").insert([
-            { user_id: human.id, match_id: matchId, goals_home: 2, goals_away: 1 },
-            { user_id: bot.id, match_id: matchId, goals_home: 0, goals_away: 3 },
+            {
+                user_id: human.id,
+                match_id: matchId,
+                goals_home: 2,
+                goals_away: 1,
+            },
+            {
+                user_id: bot.id,
+                match_id: matchId,
+                goals_home: 0,
+                goals_away: 3,
+            },
         ]);
 
-        const res = await authenticatedAgent(human).then((ag) => ag.get("/live"));
+        const res = await authenticatedAgent(human).then((ag) =>
+            ag.get("/live")
+        );
 
         expect(res.status).toBe(200);
         expect(res.text).toContain("Visible Human");

--- a/tests/routes/past.test.ts
+++ b/tests/routes/past.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { knex } from "../../db";
-import { authenticatedAgent, createTestUser, truncateTables } from "../helpers";
+import {
+    authenticatedAgent,
+    createTestUser,
+    seedMatch,
+    seedTeam,
+    truncateTables,
+} from "../helpers";
 
 describe("GET /past", () => {
     beforeEach(async () => {
@@ -25,5 +31,57 @@ describe("GET /past", () => {
 
         const res = await ag.get("/past");
         expect(res.status).toBe(200);
+    });
+
+    it("does not render bot users on the past matches page", async () => {
+        const homeTeamId = await seedTeam(knex, {
+            name: "Past Home",
+            code: "PHM",
+        });
+        const awayTeamId = await seedTeam(knex, {
+            name: "Past Away",
+            code: "PAW",
+        });
+        const matchId = await seedMatch(knex, {
+            starts_at: new Date(Date.now() - 2 * 60 * 60 * 1000),
+            home_team_id: homeTeamId,
+            away_team_id: awayTeamId,
+        });
+
+        await knex("match").where({ id: matchId }).update({
+            goals_home: 2,
+            goals_away: 1,
+            goals_inserted_at: new Date(),
+        });
+
+        const human = await createTestUser(knex, { name: "Past Human" });
+        const bot = await createTestUser(knex, {
+            email: "bot-past@example.com",
+            name: "Past Bot",
+            is_bot: true,
+        });
+
+        await knex("bet").insert([
+            {
+                user_id: human.id,
+                match_id: matchId,
+                goals_home: 2,
+                goals_away: 1,
+            },
+            {
+                user_id: bot.id,
+                match_id: matchId,
+                goals_home: 0,
+                goals_away: 2,
+            },
+        ]);
+
+        const res = await authenticatedAgent(human).then((ag) =>
+            ag.get("/past")
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.text).toContain("Past Human");
+        expect(res.text).not.toContain("Past Bot");
     });
 });


### PR DESCRIPTION
- Add `is_bot` column for users
- Hide bots on live matches page, past matches page and extra-bet list page
- Add test cases